### PR TITLE
protecting bufferoverflow to comply with gcc6

### DIFF
--- a/common-utils/filescan-utils.c
+++ b/common-utils/filescan-utils.c
@@ -53,8 +53,8 @@ PUBLIC json_object* ScanForConfig (const char* searchPath, CtlScanDirModeT mode,
                 if (dirEnt->d_name[0]=='.' || dirEnt->d_name[0]=='_') continue;
                 
                 strncpy(newpath, searchPath, sizeof(newpath)); 
-                strncat(newpath, "/", sizeof(newpath)); 
-                strncat(newpath, dirEnt->d_name, sizeof(newpath)); 
+                strncat(newpath, "/", sizeof(newpath)-strlen(newpath)-1); 
+                strncat(newpath, dirEnt->d_name, sizeof(newpath)-strlen(newpath)-1); 
                 ScanDir(newpath);
                 continue;
             }


### PR DESCRIPTION
Signed-off-by: Dominig ar Foll <dominig.arfoll@fridu.net>
gcc6 makes more check on buffer overflow and gcc6 now check for such violation possibility and reports warnings.
OBS recent release check for gcc security warning and stops the publication of the package.
This changes correct that issue.

[    7s] ... testing for serious compiler warnings
[    7s]     (using /usr/lib/build/checks-data/check_gcc_output)
[    7s]     (using /home/dominig/ssd/var/tmp/build-root/openSUSE_Leap_42.3-x86_64-home:dominig:branches:isv:LinuxAutomotive:app-Framework-agl-afb-mpdc/.build.log)
[    7s] 
[    7s] I: Statement might be overflowing a buffer in strncat. Common mistake:
[    7s]    BAD: strncat(buffer,charptr,sizeof(buffer)) is wrong, it takes the left over size as 3rd argument
[    7s]    GOOD: strncat(buffer,charptr,sizeof(buffer)-strlen(buffer)-1)
[    7s] E: agl-afb-mpdc bufferoverflowstrncat /usr/include/bits/string3.h:156
[    7s] 
[    7s] dominig-intel failed "build agl-afb-mpdc.spec" at Tue Sep 26 13:36:42 UTC 2017.
